### PR TITLE
Further developments on TnP Analyzer from nanoAOD

### DIFF
--- a/Muon_TnP_cfg.py
+++ b/Muon_TnP_cfg.py
@@ -2,23 +2,23 @@
 variables = {
     'probe' : ["charge", "pt", "eta", "dxy", "dz", "isTracker", "isStandalone", "isGlobal", "HLTIsoMu24", "tightId", "mediumId", "looseId", "highPtId", "pfIsoId", "pfAbsIso04_all"],
     "tag"   : ["charge", "pt", "eta", "dxy", "dz", "isTracker", "isStandalone", "isGlobal", "HLTIsoMu24", "tightId", "mediumId", "looseId", "highPtId", "pfIsoId", "pfAbsIso04_all"],
-    "save"  : ["pair_mass","pair_pt","pair_eta","pair_phi","event",
+    "save"  : ["pair_mass","pair_pt","pair_eta","pair_phi","eventIdx",
                "probe_charge","probe_pt","probe_eta","probe_isGlobal","probe_HLTIsoMu24","probe_dxy","probe_dz","probe_isTracker","probe_isStandalone","probe_tightId","probe_mediumId","probe_looseId","probe_highPtId","probe_pfIsoId","probe_pfAbsIso04_all",
                "tag_charge","tag_pt","tag_eta","tag_isGlobal","tag_HLTIsoMu24","tag_dxy","tag_dz","tag_isTracker","tag_isStandalone","tag_tightId","tag_mediumId","tag_looseId","tag_highPtId","tag_pfIsoId","tag_pfAbsIso04_all",
                ],
 }
 
 selection = {
-    "probe" : "Muon_isStandalone && Muon_pt > 2 && abs(Muon_eta) < 2.4",
-    "tag"   : "Muon_pt > 15 && abs(Muon_eta) < 2.4 &&  Muon_tightId && Muon_isTrig",
-    "pair"  : "All_TPmass > 60 && All_TPmass < 120" 
+    "probe" : "Muon_pt > 2 && abs(Muon_eta) < 2.4", # Muon_isStandalone
+    "tag"   : "Muon_pt > 15 && abs(Muon_eta) < 2.4 &&  Muon_tightId", # Muon_isTrig
+    "pair"  : "All_TPmass > 60" 
 }
 
 samples = {
     "Run2022" : {
         'input'  : "/eos/user/r/rbhattac/Muon_POG_NanoAOD_v2/Muon/NanoMuonPOGData2022F/231103_232820/0000/",
         "output" : "/eos/cms/store/group/phys_muon//sblancof/nanoAOD/tnp.parquet",
-        "lumiMask": "https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions23/Cert_Collisions2023_366442_370790_Golden.json",
+        "lumiMask": "https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/Cert_Collisions2022_355100_362760_Golden.json",
         "doSplit": True,
         "root_file": "tnp.root"
     }

--- a/Muon_TnP_cfg.py
+++ b/Muon_TnP_cfg.py
@@ -1,8 +1,11 @@
 ### Very first implementation of Muon TnP configurtion file
 variables = {
-    'probe' : ["charge", "pt", "eta", "isGlobal", "HLTIsoMu24"],
-    "tag"   : ["charge", "pt", "eta", "isGlobal", "HLTIsoMu24"],
-    "save"  : ["pair_mass","pair_pt","pair_eta","pair_phi","probe_charge","probe_pt","probe_eta","probe_isGlobal","tag_charge","tag_pt","tag_eta","tag_isGlobal"],
+    'probe' : ["charge", "pt", "eta", "dxy", "dz", "isTracker", "isStandalone", "isGlobal", "HLTIsoMu24", "tightId", "mediumId", "looseId", "highPtId", "pfIsoId", "pfAbsIso04_all"],
+    "tag"   : ["charge", "pt", "eta", "dxy", "dz", "isTracker", "isStandalone", "isGlobal", "HLTIsoMu24", "tightId", "mediumId", "looseId", "highPtId", "pfIsoId", "pfAbsIso04_all"],
+    "save"  : ["pair_mass","pair_pt","pair_eta","pair_phi","event",
+               "probe_charge","probe_pt","probe_eta","probe_isGlobal","probe_HLTIsoMu24","probe_dxy","probe_dz","probe_isTracker","probe_isStandalone","probe_tightId","probe_mediumId","probe_looseId","probe_highPtId","probe_pfIsoId","probe_pfAbsIso04_all",
+               "tag_charge","tag_pt","tag_eta","tag_isGlobal","tag_HLTIsoMu24","tag_dxy","tag_dz","tag_isTracker","tag_isStandalone","tag_tightId","tag_mediumId","tag_looseId","tag_highPtId","tag_pfIsoId","tag_pfAbsIso04_all",
+               ],
 }
 
 selection = {
@@ -14,7 +17,8 @@ selection = {
 samples = {
     "Run2022" : {
         'input'  : "/eos/user/r/rbhattac/Muon_POG_NanoAOD_v2/Muon/NanoMuonPOGData2022F/231103_232820/0000/",
-        "output" : "tnp.parquet",
+        "output" : "/eos/cms/store/group/phys_muon//sblancof/TnP_Muon/tnp.parquet",
+        "doSplit": True,
         "root_file": "tnp.root"
     }
 }

--- a/Muon_TnP_cfg.py
+++ b/Muon_TnP_cfg.py
@@ -17,7 +17,8 @@ selection = {
 samples = {
     "Run2022" : {
         'input'  : "/eos/user/r/rbhattac/Muon_POG_NanoAOD_v2/Muon/NanoMuonPOGData2022F/231103_232820/0000/",
-        "output" : "/eos/cms/store/group/phys_muon//sblancof/TnP_Muon/tnp.parquet",
+        "output" : "/eos/cms/store/group/phys_muon//sblancof/nanoAOD/tnp.parquet",
+        "lumiMask": "https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions23/Cert_Collisions2023_366442_370790_Golden.json",
         "doSplit": True,
         "root_file": "tnp.root"
     }

--- a/Muon_TnP_cfg.py
+++ b/Muon_TnP_cfg.py
@@ -13,7 +13,7 @@ selection = {
 
 samples = {
     "Run2022" : {
-        'input'  : "/gpfs/ddn/srm/cms/store/user/rbhattac/Muon_POG_NanoAOD_v2/Muon/NanoMuonPOGData2022F/231103_232820/",
+        'input'  : "/eos/user/r/rbhattac/Muon_POG_NanoAOD_v2/Muon/NanoMuonPOGData2022F/231103_232820/0000/",
         "output" : "tnp.parquet",
         "root_file": "tnp.root"
     }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Muon POG nanoAOD Tag&Probe tool
+
+This tool is intended to be plugin within the spark_tnp framework [https://gitlab.cern.ch/cms-muonPOG/spark_tnp]. It takes as input Muon nanoAOD files and return parquet files with Tag muon and Probe muon pair ntuples.
+
+## Install
+
+Install the environment:
+
+```
+git clone ....
+./install
+```
+
+Once ready, setup the environment everytime you wish to run the code:
+
+```
+source start.sh
+```
+
+## Run TnP workflow
+
+The configuration file Muon_TnP_cfg.py needs to be fill everytime you want to register a new production campaign. Then, a few options are considered.
+
+```
+**Options**
+-p (--prod)     PRODUCTION NAME
+-s (--doSubmit) SUBMIT JOBS TO CONDOR (0 or 1)
+-F (--selFile)  RUN ON ONE SINGLE FILE
+-dR (--dryRun)  DRY RUN / DO NOT SUBMIT (0 or 1)
+```
+
+**Split and submit jobs to HTCondor (Recommended):**
+
+```
+python TNP_Muon_POG.py -p PRODUCTION -s 1 
+```
+
+Run the code interactively:
+
+```
+python TNP_Muon_POG.py -p PRODUCTION 
+```
+
+The code returns one parquet file per ROOT input file. They can be merged easly in hadoop using the spark_tnp tool. Once there, you can setup the input and output directories and run:
+
+```
+python doMerge.py
+```
+
+# Time consumption
+
+## First step: TnP ntuple creation
+
+```
+Time per job: < 2 minutes
+```
+
+## Second step: Merge files
+
+Should depend on the batch size. First attemp using 100 files.
+
+```
+Time to merge: ~5 minutes
+```
+
+
+
+
+
+
+

--- a/TNP_Muon_POG.h
+++ b/TNP_Muon_POG.h
@@ -17,7 +17,7 @@ RVecI CreateTrigIndex(const RVecF Muon_eta,
 		      const RVecF TrigObj_phi,
 		      const float minDR)
 {
-  RVecI Muon_TrigIdx(Muon_eta.size(), -1);
+  RVecI Muon_TrigIdx(Muon_eta.size(), 999);
   float dR = 999.9;
   for (int iMu=0; iMu < Muon_eta.size(); iMu++){
     float tmpDR = minDR;
@@ -74,11 +74,23 @@ RVec<Float_t> getTPVariables(RVec<std::pair<int,int>> TPPairs,
   
 }
 
+RVecB getDuplicatedProbes(RVec<std::pair<int,int>> TPPairs, RVec<Float_t> &Cand_pt)
+{
+  RVecB Cand_duplicated(false, Cand_pt.size());
+  RVecI Cand_index;
+  for (int i=0;i<TPPairs.size();i++){
+    Cand_index.push_back(TPPairs.at(i).second);
+  }
+  for (int i=0;i<Cand_index.size();i++){
+    if (Sum(Cand_index==Cand_index[i])>1) Cand_duplicated[Cand_index[i]] = true;
+  }
+  return Cand_duplicated;  
+}
 
 template <typename T>
 RVec<T> getVariables(RVec<std::pair<int,int>> TPPairs,
                      RVec<T>  &Cand_variable,
-                     int option /*1 for tag and 2 for probe*/)
+                     int option /*1 for tag, 2 for probe*/)
 {
     RVec<T>  Variables(TPPairs.size(), 0);
     for (int i = 0; i < TPPairs.size(); i++){

--- a/TNP_Muon_POG.h
+++ b/TNP_Muon_POG.h
@@ -41,11 +41,11 @@ RVec<std::pair<int,int>> CreateTPPair(const RVec<Int_t> &Tag_muons,
 {
   RVec<std::pair<int,int>> TP_pairs;
   for (int iLep1 = 0; iLep1 < Tag_muons.size(); iLep1++) {
-    if (not Tag_muons[iLep1]) continue;
+    if (!Tag_muons[iLep1]) continue;
     for(int iLep2 = 0; iLep2 < Probe_Candidates.size(); iLep2++){
       if (isSameCollection && (iLep1 == iLep2)) continue;
-      if (not Probe_Candidates[iLep2]) continue;
-      if (doOppositeCharge and (Tag_Charge[iLep1] == Probe_charge[iLep2])) continue;
+      if (!Probe_Candidates[iLep2]) continue;
+      if (doOppositeCharge && (Tag_Charge[iLep1] == Probe_charge[iLep2])) continue;
       std::pair<int,int> TP_pair = std::make_pair(iLep1, iLep2);
       TP_pairs.push_back(TP_pair);
     }          

--- a/TNP_Muon_POG.py
+++ b/TNP_Muon_POG.py
@@ -169,7 +169,7 @@ def create_TnP_pairs(era, fileName=""):
         df = df.Define("tag_"+var, "getVariables(TPPairs, Muon_"+var+", 1)")
 
     ### Additional variables
-    df = df.Redefine("event", "RVecI(pair_mass.size(), event)")
+    df = df.Define("eventIdx", "RVecD(pair_mass.size(), event)")
         
     loop_time = time.time()
     print("Time taken to loop = ",(loop_time -start))

--- a/TNP_Muon_POG.py
+++ b/TNP_Muon_POG.py
@@ -2,18 +2,22 @@
 
 
 import ROOT
-import numpy as np
-import awkward as ak
 from sys import exit
-import sys
-import pandas as pd
 import time
 from Muon_TnP_cfg import *
-import uproot
 import os
+import subprocess
+import sys
+sys.path.insert(0, list(filter(lambda k: 'myenv' in k, sys.path))[0])
+import uproot
+import awkward as ak
+import pandas as pd
+import numpy as np
+
+from math import ceil
 
 ROOT.gInterpreter.ProcessLine(".O3")
-ROOT.ROOT.EnableImplicitMT()
+#ROOT.EnableImplicitMT(1)
 ROOT.gInterpreter.Declare('#include "headers.hh"')
 ROOT.gInterpreter.Declare('#include "TNP_Muon_POG.h"') 
 
@@ -22,22 +26,28 @@ ROOT.gInterpreter.Declare('#include "TNP_Muon_POG.h"')
 def create_TnP_pairs(era):
     
     start = time.time()
-    
+
+    print("Start computation!")
     
     #### Read input files
     files = []
-    for i in range(len(samples[era]["input"])):
-        for root, dirnames, filenames in os.walk(samples[era]["input"][i]):
-            for filename in filenames:
-                if '.root' in filename:
-                    files.append(os.path.join(root, filename))
+    cmd = "find {} -wholename '*/*.root'".format(samples[era]["input"])
+    fnames = subprocess.check_output(cmd, shell=True).strip().split(b'\n')
+    files = files + [fname.decode('ascii') for fname in fnames]
 
+    print(files[0:10])
+
+    files = files[0:10]
+    #files = ["/eos/user/r/rbhattac/Muon_POG_NanoAOD_v2/Muon/NanoMuonPOGData2022F/231103_232820/0000/NanoMuonPOGData_22F_test_1-1.root"]
     filenames = ROOT.std.vector('string')()
-
     for name in files: filenames.push_back(name)
 
-    
+    print(filenames)
+
+    print("Creating datframe")
     df = ROOT.RDataFrame("Events",filenames)
+
+    print("Number of events -> " + str(df.Count().GetValue()))
     
     # just for utility
     df = df.Alias("Tag_pt",  "Muon_pt")
@@ -81,36 +91,85 @@ def create_TnP_pairs(era):
     ### Create Tag branches
     for var in variables["tag"]:
         df = df.Define("tag_"+var, "getVariables(TPPairs, Muon_"+var+", 1)")
-        
-        
-    #This gives you a  numpy.array(RVec)
-    npy = df.AsNumpy(variables["save"])
-    
+
+
     loop_time = time.time()
     print("Time taken to loop = ",(loop_time -start))
     
+    # ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    
+    #This gives you a  numpy.array(RVec)
+    npy = df.AsNumpy(variables["save"])
+    
     #This gives you a pd dataframe where each element is a Rvec. Not the format we want. 
     #Need to flatten it before using it form Tag and Probe 
-    df_pd = pd.DataFrame(npy)
+    #df_pd = pd.DataFrame(npy)
     
-    print("Content of the ROOT.RDataFrame as pandas.DataFrame:\n{}\n".format(df_pd))
-    default_pd_time = time.time()
-    print("Time taken to save default pd dataframe = ",(default_pd_time - loop_time))
+    #print("Content of the ROOT.RDataFrame as pandas.DataFrame:\n{}\n".format(df_pd))
+    #default_pd_time = time.time()
+    #print("Time taken to save default pd dataframe = ",(default_pd_time - loop_time))
     
     #Flatten implementations. Below you can see 2 different implementations.
     
     #Using the flatten method of Awkward array. Slow compare to the numpy implementation
     #Numpy option is better so no need to use it
+
     test_df = {}
     for key in npy:
         test_ak = [ak.Array(v) for v in npy[key]]
         test_np = ak.to_numpy(ak.flatten(test_ak))
         test_df[key] = test_np
     df_ak = pd.DataFrame(test_df)
-    print(df_ak)
+    
+    df_ak.to_parquet("tnp_ak.parquet", engine='fastparquet')
     
     df_ak_time = time.time()
-    print("Time taken to create df_ak = ", (df_ak_time - default_pd_time))
+
+    print("Time taken to create and save df_ak = ", (df_ak_time - loop_time))
+
+    # -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
+    
+    #######
+    ####### Test chunck apporach with awkward 2.4!
+    #######
+        
+    chunksize = 10_000
+    nIterations = max(ceil(df.Count().GetValue() / chunksize), 1)
+    outFile = "test_" + samples[era]["output"]
+    branches = variables["save"]
+    first = True
+
+    default_pd_time = time.time()
+
+    print("Total number of iterations -> " + str(nIterations))
+    
+    for i in range(nIterations):
+        #if (i%10 == 0): print("Iteration: " + str(i))
+        print("Iteration: " + str(i))
+        _df = df.Range( i * chunksize, (i+1) * chunksize)
+        events = ak.from_rdataframe(_df, branches)
+        def getBranchFlatten(events, branch):
+            ak_array = [ak.Array(v) for v in events[branch]]
+            np_array = ak.to_numpy(ak.flatten(ak_array))
+            return np_array
+        
+        df_np = {}
+        for key in branches:
+            df_np[key] = getBranchFlatten(events, key)
+        df_ak = pd.DataFrame(df_np)
+        if first:
+            df_ak.to_parquet(outFile, engine='fastparquet', append=False)
+            first=False
+        else:
+            df_ak.to_parquet(outFile, engine='fastparquet', append=True)
+
+    print("Parquet done!")
+    df_ak_time = time.time()  
+    print("Time to create and save parquet = ", (df_ak_time - default_pd_time)) 
+
+    # -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
+    '''
+    df_np_time = time.time()
     
     #Numpy implementation. Flatten option of numpy directly does not work since this is 
     #a jagged array. 
@@ -122,7 +181,6 @@ def create_TnP_pairs(era):
     df_np = pd.DataFrame(test_df_np)
     print(df_np)
     
-    df_np_time = time.time()
     print("Time taken to create df_np = ", (df_np_time - default_pd_time))
     
     df_np.to_parquet(samples[era]["output"])
@@ -133,9 +191,9 @@ def create_TnP_pairs(era):
     
     print("Total time = ", (df_np_time - start))
 
-    out_file = uproot.recreate(samples[era]["root_file"])
-    out_file["tnp_tree"] = df_np
-
+    #out_file = uproot.recreate(samples[era]["root_file"])
+    #out_file["tnp_tree"] = df_np
+    '''
     
 
 if __name__ == '__main__':

--- a/doMerge.py
+++ b/doMerge.py
@@ -1,0 +1,79 @@
+from __future__ import print_function
+import os
+import sys
+import glob
+import itertools
+
+from pyspark.ml.feature import Bucketizer
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql.functions import pandas_udf, PandasUDFType
+
+import subprocess
+
+spark = SparkSession\
+    .builder\
+    .master("yarn")\
+    .appName("TnP")
+
+spark = spark\
+    .config("spark.sql.broadcastTimeout", "36000")\
+    .config("spark.network.timeout", "600s")\
+    .config("spark.driver.memory", "6g")\
+    .config("spark.executor.memory", "10g")\
+    .config("spark.executorEnv.PYTHONPATH", os.environ.get('PYTHONPATH'))\
+    .config("spark.executorEnv.LD_LIBRARY_PATH", os.environ.get('LD_LIBRARY_PATH'))
+
+spark = spark.getOrCreate()
+
+n = len(sys.argv)
+print(sys.argv)
+if n<3:
+    print("Error: Not enough input parameters \n")
+    print("Try like this: \n")
+    print("doMerge.py inputDir outputFile")
+    print("------------------------------")
+    sys.exit()
+
+input_directory = sys.argv[1]
+outFile = sys.argv[2]
+if n==4:
+    batch = int(sys.argv[3])
+else:
+    batch = 100
+
+print("Start running doMerge.py!")
+print(">>>>> Input directory : " + input_directory)
+print(">>>>> Output file     : " + outFile)
+print(">>>>> batch           : " + str(batch))
+print("------------------------------")
+
+if ("hdfs://analytix" not in input_directory) or ("hdfs://analytix" not in outFile):
+    print(">>>>>>>> Remember to use the correct Hadoop syntax")
+    print(">>>>>>>> Path should start with:  hdfs://analytix")
+    print("--------------------------------------------------")
+    sys.exit()
+
+cmd = "hdfs dfs -find {} -name '*.parquet'".format(input_directory)
+fnames = subprocess.check_output(cmd, shell=True).strip().split(b'\n')
+fnames = [fname.decode('ascii') for fname in fnames]
+
+print(fnames)
+
+first = True
+
+while fnames:
+    current = fnames[:batch]
+    fnames = fnames[batch:]
+
+    baseDF = spark.read.parquet(*current)
+    if first:
+        baseDF.write.parquet(outFile)
+        first = False
+    else:
+        baseDF.write.mode('append').parquet(outFile)
+
+
+
+
+

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: cern
+channels:
+  - conda-forge
+dependencies:
+  - pip
+  - root
+  - boost
+  - gcc
+  - cmake
+  - ninja

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+### Setup an environment to make the TnP analysis
+sourceCommand="source /cvmfs/sft.cern.ch/lcg/views/LCG_104a/x86_64-el9-gcc11-opt/setup.sh"
+
+eval "$sourceCommand"
+python -m venv --system-site-packages myenv
+source myenv/bin/activate
+
+python -m pip install -e .[docs,dev]
+
+python -m pip install --no-binary=correctionlib correctionlib
+
+cat << EOF > start.sh
+#!/bin/bash
+$sourceCommand
+source `pwd`/myenv/bin/activate
+EOF
+
+chmod +x start.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = ["setuptools >= 59.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = [
+		  "tests"
+]
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,17 @@
+[options]
+zip_safe = False
+install_requires = 
+    requests
+    tabulate
+    cloudpickle
+    uproot==5.0.11
+    awkward==2.4.3
+    fastparquet
+
+packages = find_namespace:
+package_dir =
+    = .
+
+[options.package_data]
+* = 
+  *


### PR DESCRIPTION
This PR includes the new validated version of the code. New implementation:

- Bug fixed on the c++ functions to create the tag and probe pairs. 
- New installation of the code using pip and python environments
- Batch submission with file split option
- Merge parquet files (within spark_tnp environment)
- Save dataset iteratively using ak.from_rdataframe (x2 faster)
- Define new variables such as duplicated probes

Validation -> [SF (old) - SF (new)] < 0.2% difference

New: https://sblancof.web.cern.ch/sblancof/MuonPOG/NanoAOD/Run2022F_nanoAOD/plots/muon/generalTracks/Z/Run2022_EE/NUM_TightID_DEN_TrackerMuons/efficiency/NUM_TightID_DEN_TrackerMuons_abseta_pt.png

Old: https://sblancof.web.cern.ch/sblancof/MuonPOG/NanoAOD/Run2022F_miniAOD/plots/muon/generalTracks/Z/Run2022_EE/NUM_TightID_DEN_TrackerMuons/efficiency/NUM_TightID_DEN_TrackerMuons_abseta_pt.png

